### PR TITLE
Update to coverage 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires=['nose', 'coverage<3.4'],
+    install_requires=['nose', 'coverage<=3.4'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Thanks again for writing this plug-in.  

The setup.py in this code causes coverage 3.4b2 to be installed, causing a lot of fixes in 3.4 (i.e. package names output in XML out of order, no conditional branch reporting, etc) to be missed.  

This wasn't obvious until I ended up tracing the issue and then finding that coverage 3.4 had already fixed this issue -- more background here (more for my own record, and anyone else who's curious) http://hustoknow.blogspot.com/2011/03/coveragepy-xml-outputs-in-random-order.html

Coverage 3.4 seems to have a lot of big fixes, which is one more reason to update!

Thanks again.
