### PR TITLE
Don't print coverage information to stdout

### DIFF
--- a/nosexcover/nosexcover.py
+++ b/nosexcover/nosexcover.py
@@ -46,7 +46,7 @@ class XCoverage(cover.Coverage):
         super(XCoverage, self).configure(options, config)
         self.xcoverageFile = options.xcoverage_file
         
-        to_stdout = options.xcoverage_to_stdout
+        to_stdout = str(options.xcoverage_to_stdout)
         self.xcoverageToStdout = False if '0' in to_stdout or 'false' in to_stdout.lower() else True
 
     def report(self, stream):


### PR DESCRIPTION
Added feature to avoid printing coverage information to stdout. This is specially useful for the use-case when we run nosetests in jenkins and we don't really care about the stdout because jenkins will parse the XML file and the stdout information just fills the log.

Don't print information to stdout:

```
pablo@eulogia:~/workspace/nose-xcover-andresriancho$ rm coverage.xml 
pablo@eulogia:~/workspace/nose-xcover-andresriancho$ nosetests -s --with-xcoverage --cover-erase --xcoverage-to-stdout=0
.
----------------------------------------------------------------------
Ran 1 test in 0.015s

OK
```

But still write the coverage.xml file:

```
pablo@eulogia:~/workspace/nose-xcover-andresriancho$ head coverage.xml 
<?xml version="1.0" ?>
...
pablo@eulogia:~/workspace/nose-xcover-andresriancho$ rm coverage.xml 
```

Print to stdout (which is also the default):

```
pablo@eulogia:~/workspace/nose-xcover-andresriancho$ nosetests -s --with-xcoverage --cover-erase --xcoverage-to-stdout=1
.
Name                                                                                      Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------------------------------------------------
/usr/local/lib/python2.7/dist-packages/nose/case                                            204    163    20%   5-27, 30, 35, 44, 47-56, 61-62, 66, 71-72, 76-115, 134-138, 142, 150, 153-196, 199-217, 245-260, 264, 269, 273, 278-397
...
-----------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                      2608   1940    26%   
----------------------------------------------------------------------
Ran 1 test in 0.015s

OK
```

And also the file is written:

```
pablo@eulogia:~/workspace/nose-xcover-andresriancho$ head coverage.xml 
<?xml version="1.0" ?>
...
pablo@eulogia:~/workspace/nose-xcover-andresriancho$ 
```
