### PR TITLE
Monkeypatch cover.log while intializing nosexcover so that log messages say nose.plugins.xcover instead of nose.plugins.cover

### DIFF
--- a/nosexcover/nosexcover.py
+++ b/nosexcover/nosexcover.py
@@ -43,7 +43,11 @@ class XCoverage(cover.Coverage):
                 """You can not use both --with-xcover and --with-coverage. Using --with-xcover implies --with-coverage""")
             raise TypeError
 
+        cover.old_log = cover.log
+        cover.log = log
         super(XCoverage, self).configure(options, config)
+        cover.log = cover.old_log
+
         self.xcoverageFile = options.xcoverage_file
         
         to_stdout = str(options.xcoverage_to_stdout)


### PR DESCRIPTION
This is on the hacky side...

Maybe it's just me, but I've been irritated for a while by the fact that when I run nosetests, it outputs the same log message twice:

```
nose.plugins.cover: INFO: Coverage report will include only packages: ['profilesvc']
nose.plugins.cover: INFO: Coverage report will include only packages: ['profilesvc']
```

This made me wonder whether I had some bug in my configuration or if there was a bug in the cover plugin.

I finally looked at it tonight and I realized that this happens because `nosexcover.XCoverage` inherits from `cover.Coverage` and calls its `configure` method, so `cover.Coverage.configure` gets called once my `nosexcover` and once by the nose plugin manager.

My attempt at making it at least clearer what's happening was this PR which does a little bit of monkeypatching so that one log message says `nose.plugins.cover` and one says `nose.plugins.xcover` -- at least that makes it a little more clear why the message is printed twice.

```
nose.plugins.xcover: INFO: Coverage report will include only packages: ['profilesvc']
nose.plugins.cover: INFO: Coverage report will include only packages: ['profilesvc']
```

Not sure this is a ton better, but maybe this will spark some more ideas on how to deal with the situation.
