### PR TITLE
Slightly better test that detects import-time problems

### DIFF
--- a/nosexcover/__init__.py
+++ b/nosexcover/__init__.py
@@ -1,1 +1,1 @@
-from nosexcover import *
+from .nosexcover import XCoverage

--- a/nosexcover/tests.py
+++ b/nosexcover/tests.py
@@ -1,2 +1,2 @@
 def test_sanity():
-    assert True
+    from nosexcover import XCoverage


### PR DESCRIPTION
For example, this would've detected the Python 3 problem in #20.

```
 ❯ tox
GLOB sdist-make: /Users/marca/dev/git-repos/nose-xcover/setup.py
py26 inst-nodeps: /Users/marca/dev/git-repos/nose-xcover/.tox/dist/nosexcover-1.0.9.zip
py26 runtests: PYTHONHASHSEED='3189573173'
py26 runtests: commands[0] | nosetests -v nosexcover/tests.py
nosexcover.tests.test_sanity ... ok

----------------------------------------------------------------------
Ran 1 test in 0.001s

OK
py27 inst-nodeps: /Users/marca/dev/git-repos/nose-xcover/.tox/dist/nosexcover-1.0.9.zip
py27 runtests: PYTHONHASHSEED='3189573173'
py27 runtests: commands[0] | nosetests -v nosexcover/tests.py
nosexcover.tests.test_sanity ... ok

----------------------------------------------------------------------
Ran 1 test in 0.001s

OK
py30 create: /Users/marca/dev/git-repos/nose-xcover/.tox/py30
ERROR: InterpreterNotFound: python3.0
py31 create: /Users/marca/dev/git-repos/nose-xcover/.tox/py31
ERROR: InterpreterNotFound: python3.1
py32 inst-nodeps: /Users/marca/dev/git-repos/nose-xcover/.tox/dist/nosexcover-1.0.9.zip
py32 runtests: PYTHONHASHSEED='3189573173'
py32 runtests: commands[0] | nosetests -v nosexcover/tests.py
/Users/marca/dev/git-repos/nose-xcover/.tox/py32/lib/python3.2/site-packages/nose/plugins/manager.py:395: RuntimeWarning: Unable to load plugin xcover = nosexcover.nosexcover:XCoverage: No module named StringIO
  RuntimeWarning)
Failure: ImportError (No module named StringIO) ... ERROR

======================================================================
ERROR: Failure: ImportError (No module named StringIO)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/nose-xcover/.tox/py32/lib/python3.2/site-packages/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "/Users/marca/dev/git-repos/nose-xcover/.tox/py32/lib/python3.2/site-packages/nose/loader.py", line 411, in loadTestsFromName
    addr.filename, addr.module)
  File "/Users/marca/dev/git-repos/nose-xcover/.tox/py32/lib/python3.2/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/Users/marca/dev/git-repos/nose-xcover/.tox/py32/lib/python3.2/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/Users/marca/dev/git-repos/nose-xcover/nosexcover/__init__.py", line 1, in <module>
    from .nosexcover import XCoverage
  File "/Users/marca/dev/git-repos/nose-xcover/nosexcover/nosexcover.py", line 7, in <module>
    import StringIO
ImportError: No module named StringIO

----------------------------------------------------------------------
Ran 1 test in 0.001s

FAILED (errors=1)
ERROR: InvocationError: '/Users/marca/dev/git-repos/nose-xcover/.tox/py32/bin/nosetests -v nosexcover/tests.py'
py33 inst-nodeps: /Users/marca/dev/git-repos/nose-xcover/.tox/dist/nosexcover-1.0.9.zip
py33 runtests: PYTHONHASHSEED='3189573173'
py33 runtests: commands[0] | nosetests -v nosexcover/tests.py
/Users/marca/dev/git-repos/nose-xcover/.tox/py33/lib/python3.3/site-packages/nose/plugins/manager.py:395: RuntimeWarning: Unable to load plugin xcover = nosexcover.nosexcover:XCoverage: No module named 'StringIO'
  RuntimeWarning)
Failure: ImportError (No module named 'StringIO') ... ERROR

======================================================================
ERROR: Failure: ImportError (No module named 'StringIO')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/nose-xcover/.tox/py33/lib/python3.3/site-packages/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "/Users/marca/dev/git-repos/nose-xcover/.tox/py33/lib/python3.3/site-packages/nose/loader.py", line 411, in loadTestsFromName
    addr.filename, addr.module)
  File "/Users/marca/dev/git-repos/nose-xcover/.tox/py33/lib/python3.3/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/Users/marca/dev/git-repos/nose-xcover/.tox/py33/lib/python3.3/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/Users/marca/dev/git-repos/nose-xcover/.tox/py33/lib/python3.3/imp.py", line 190, in load_module
    return load_package(name, filename)
  File "/Users/marca/dev/git-repos/nose-xcover/.tox/py33/lib/python3.3/imp.py", line 160, in load_package
    return _bootstrap.SourceFileLoader(name, path).load_module(name)
  File "<frozen importlib._bootstrap>", line 584, in _check_name_wrapper
  File "<frozen importlib._bootstrap>", line 1022, in load_module
  File "<frozen importlib._bootstrap>", line 1003, in load_module
  File "<frozen importlib._bootstrap>", line 560, in module_for_loader_wrapper
  File "<frozen importlib._bootstrap>", line 868, in _load_module
  File "<frozen importlib._bootstrap>", line 313, in _call_with_frames_removed
  File "/Users/marca/dev/git-repos/nose-xcover/nosexcover/__init__.py", line 1, in <module>
    from .nosexcover import XCoverage
  File "/Users/marca/dev/git-repos/nose-xcover/nosexcover/nosexcover.py", line 7, in <module>
    import StringIO
ImportError: No module named 'StringIO'

----------------------------------------------------------------------
Ran 1 test in 0.002s

FAILED (errors=1)
ERROR: InvocationError: '/Users/marca/dev/git-repos/nose-xcover/.tox/py33/bin/nosetests -v nosexcover/tests.py'
___________________________________________________________________________________ summary ____________________________________________________________________________________
  py26: commands succeeded
  py27: commands succeeded
ERROR:   py30: InterpreterNotFound: python3.0
ERROR:   py31: InterpreterNotFound: python3.1
ERROR:   py32: commands failed
ERROR:   py33: commands failed
```
