### PR TITLE
Clarify readme with --with-xcoverage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ It will honor all the options you pass to the `Nose coverage plugin <http://some
 
 Usage
 ------
-You can not use both --with-xcover and --with-coverage.  Using --with-xcover implies --with-coverage
+You can not use both --with-xcoverage and --with-coverage.  Using --with-xcover implies --with-coverage
 
 If you want to change the name of the output file you can use --xcoverage-file=FILE (--cover-xml-file from coverage won't work)
 


### PR DESCRIPTION
--with-xcover is not the correct option and may cause confusion amongst users.